### PR TITLE
west.yml: add fatfs module to the project

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -8,6 +8,8 @@ manifest:
   remotes:
     - name: xentroops
       url-base: https://github.com/xen-troops/
+    - name: zephyrproject-rtos
+      url-base: https://github.com/zephyrproject-rtos/
 
   projects:
     - name: zephyr
@@ -17,3 +19,6 @@ manifest:
     - name: zephyr-xenlib
       remote: xentroops
       revision: main
+    - name: fatfs
+      remote: zephyrproject-rtos
+      revision: master


### PR DESCRIPTION
FatFs support requires fatfs module to be added to the west.yml.